### PR TITLE
tmp bundler fix for "can't modify frozen String"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,6 +16,11 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
+            # tmp bundler fix for "Gem::Ext::BuildError: ERROR: Failed to build gem native extension."
+            # "can't modify frozen String"
+            # see: https://github.com/bundler/bundler/issues/5357#issuecomment-274742137
+            sudo gem update --system
+            #
             bundle install --with test
             bundle exec rspec
             bundle exec rubocop


### PR DESCRIPTION
tmp bundler fix for

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
can't modify frozen String
```

see: https://github.com/bundler/bundler/issues/5357#issuecomment-274742137